### PR TITLE
mavlink: filter out messages with no time_boot_ms field

### DIFF
--- a/mavlink_common_v1.0/mavlink.js
+++ b/mavlink_common_v1.0/mavlink.js
@@ -18696,7 +18696,10 @@ MAVLink.prototype.parseType = function (type) {
                 index -= 1
             }
         }
-        messages.push(m)
+        // This filters out the first messages, which have no time_boot_ms information
+        if (m.time_boot_ms !== 0) {
+            messages.push(m)
+        }
     }
     this.emit('message', messages)
     return messages


### PR DESCRIPTION
Fix #81