### PR TITLE
Plotly: make shapes not editable (remove cursor events)

### DIFF
--- a/src/components/Plotly.vue
+++ b/src/components/Plotly.vue
@@ -596,4 +596,8 @@ export default {
     .js-plotly-plot {
         margin-left: 0 !important;
     }
+
+    .shapelayer path {
+        pointer-events: none !important;
+    }
 </style>


### PR DESCRIPTION
plotly is kinda broken right now in https://tlog.galvanicloop.com. It lets you drag the mode shapes around and the data cursor is not working. this fixes that