### PR TITLE
Plotly: add annotations for when vehicle is armed/disarmed

### DIFF
--- a/src/components/Globals.js
+++ b/src/components/Globals.js
@@ -7,6 +7,7 @@ export var store = {
     show_radio: false,
     show_messages: false,
     flight_mode_changes: [],
+    armed_events: [],
     cssColors: [],
     colors: [],
     map_available: false,

--- a/src/components/Plotly.vue
+++ b/src/components/Plotly.vue
@@ -323,6 +323,7 @@ export default {
                         }
                     })
                     this.addModeShapes()
+                    this.addEvents()
                 }
             }
         },
@@ -538,6 +539,27 @@ export default {
             }
             Plotly.relayout(this.gd, {
                 shapes: shapes
+            })
+        },
+        addEvents () {
+            let annotations = []
+            for (let i of this.state.armed_events) {
+                annotations.push(
+                    {
+                        xref: 'x',
+                        yref: 'paper',
+                        x: i[0],
+                        y: 0.07,
+                        yanchor: 'bottom',
+                        text: i[1] ? 'Armed' : 'Disarmed',
+                        showarrow: true,
+                        ay: 50,
+                        ax: 0
+                    }
+                )
+            }
+            Plotly.relayout(this.gd, {
+                annotations: annotations
             })
         }
     },

--- a/src/tools/parsers/dataflashParser.js
+++ b/src/tools/parsers/dataflashParser.js
@@ -619,6 +619,7 @@ export class DataflashParser {
         this.parse_atOffset('XKQ2')
         this.parse_atOffset('PARM')
         this.parse_atOffset('MSG')
+        this.parse_atOffset('STAT')
         let metadata = {
             startTime: this.extractStartTime()
         }


### PR DESCRIPTION
this shows when the vehicle was armed/disarmed in the plot:
![Screenshot from 2019-12-06 18-20-18](https://user-images.githubusercontent.com/4013804/70357269-40ff9580-1855-11ea-82ef-8516d69ec32f.png)
