### PR TITLE
Plotly: encode flight modes in plot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6822,7 +6822,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
       "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -6900,7 +6899,6 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@babel/register": "^7.7.4",
     "bootstrap-vue": "^2.1.0",
+    "color": "^3.1.2",
     "colormap": "^2.3.1",
     "epic-spinners": "^1.1.0",
     "jquery": "^3.4.1",

--- a/src/components/CesiumViewer.vue
+++ b/src/components/CesiumViewer.vue
@@ -1,5 +1,14 @@
 <template>
     <div id="wrapper">
+        <div id="toolbar">
+            <table class="infoPanel">
+                <tbody>
+                <tr v-bind:key="index" v-for="(mode, index) in setOfModes">
+                    <td class="mode" v-bind:style="{ color: state.cssColors[index] } ">{{ mode }}</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
         <div id="cesiumContainer"></div>
     </div>
 </template>
@@ -798,20 +807,21 @@ export default {
         color: #eee;
         font-family: 'Montserrat', sans-serif;
         font-size: 9pt;
+        z-index: 1;
     }
+
+    /* INFO PANEL */
 
     .infoPanel {
-        background: rgba(42, 42, 42, 0.8);
-        margin: 5px;
-        border: 1px solid #444;
-        border-radius: 10px;
-        font-size: 100%;
+        background: rgba(41, 41, 41, 0.678);
+        padding: 5px;
+        border-collapse: separate;
+        margin: 8px;
+        border-radius: 5px;
         font-weight: bold;
         float: left;
-    }
-
-    .infoPanel > tbody {
-        padding: 15px;
+        box-shadow: inset 0 0 10px rgb(0, 0, 0);
+        letter-spacing: 1px;
     }
 
     #wrapper {

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -31,15 +31,6 @@
                         <CesiumViewer ref="cesiumViewer"/>
                     </div>
                 </div>
-                <div id="toolbar">
-                    <table class="infoPanel">
-                        <tbody>
-                        <tr v-bind:key="index" v-for="(mode, index) in setOfModes">
-                            <td class="mode" v-bind:style="{ color: state.cssColors[index] } ">{{ mode }}</td>
-                        </tr>
-                        </tbody>
-                    </table>
-                </div>
             </main>
 
         </div>
@@ -243,31 +234,6 @@ export default {
         opacity: 0.75;
         text-align: center;
     }
-
-    #toolbar {
-        margin: 5px;
-        padding: 2px 5px;
-        position: absolute;
-        top: 0;
-        color: #eee;
-        font-family: 'Montserrat', sans-serif;
-        font-size: 9pt;
-    }
-
-    /* INFO PANEL */
-
-    .infoPanel {
-        background: rgba(41, 41, 41, 0.678);
-        padding: 5px;
-        border-collapse: separate;
-        margin: 8px;
-        border-radius: 5px;
-        font-weight: bold;
-        float: left;
-        box-shadow: inset 0 0 10px rgb(0, 0, 0);
-        letter-spacing: 1px;
-    }
-
     /* ATOM SPINNER */
 
       div .atom-spinner {

--- a/src/components/Plotly.vue
+++ b/src/components/Plotly.vue
@@ -5,6 +5,7 @@
 <script>
 import Plotly from 'plotly.js'
 import {store} from './Globals.js'
+let Color = require('color')
 
 let timeformat = ':02,2f'
 let plotOptions = {
@@ -107,8 +108,6 @@ let plotOptions = {
 
 }
 
-Plotly.editable = true
-Plotly.edits = {legendPosition: true}
 export default {
     created () {
         this.$eventHub.$on('cesium-time-changed', this.setCursorTime)
@@ -521,6 +520,9 @@ export default {
         getModeColor (time) {
             return this.state.cssColors[this.setOfModes.indexOf(this.getMode(time))]
         },
+        darker (color) {
+            return Color(color).darken(0.2).string()
+        },
         addModeShapes () {
             let shapes = []
             let modeChanges = this.state.flight_mode_changes
@@ -539,7 +541,7 @@ export default {
                         x1: modeChanges[i + 1][0],
                         y1: 1,
                         fillcolor: this.getModeColor(modeChanges[i][0] + 1),
-                        opacity: 0.2,
+                        opacity: 0.15,
                         line: {
                             width: 0
                         }
@@ -558,12 +560,33 @@ export default {
                         xref: 'x',
                         yref: 'paper',
                         x: i[0],
-                        y: 0.07,
+                        y: 0,
                         yanchor: 'bottom',
                         text: i[1] ? 'Armed' : 'Disarmed',
                         showarrow: true,
-                        ay: 50,
+                        ay: 30,
                         ax: 0
+                    }
+                )
+            }
+            let modeChanges = this.state.flight_mode_changes
+            modeChanges.push([this.gd.layout.xaxis.range[1], null])
+            for (let i = 0; i < modeChanges.length - 1; i++) {
+                annotations.push(
+                    {
+                        xref: 'x',
+                        // y-reference is assigned to the plot paper [0,1]
+                        yref: 'paper',
+                        x: modeChanges[i][0],
+                        xanchor: 'left',
+                        y: 0,
+                        textangle: 90,
+                        text: '<b>' + modeChanges[i][1] + '</b>',
+                        showarrow: false,
+                        font: {
+                            color: this.darker(this.getModeColor(modeChanges[i][0] + 1))
+                        },
+                        opacity: 1
                     }
                 )
             }


### PR DESCRIPTION
With this, we no longer need that cesium-style flight mode legend over the plot
![Screenshot from 2019-12-14 12-05-08](https://user-images.githubusercontent.com/4013804/70850528-0e175c00-1e6a-11ea-82ce-263ff278a261.png)
